### PR TITLE
Add mid-boost dialogue to custom ascend manager

### DIFF
--- a/SaladimHelper/ModFolder/Loenn/entities/customAscendManager.lua
+++ b/SaladimHelper/ModFolder/Loenn/entities/customAscendManager.lua
@@ -1,16 +1,24 @@
 local entity = {}
+
 entity.name = "SaladimHelper/CustomAscendManager"
 entity.depth = 0
 entity.texture = "@Internal@/summit_background_manager"
+entity.fieldInformation = {
+	backgroundColor = {
+        fieldType = "color"
+    }
+}
+
 entity.placements = {
     name = "normal",
     data = {
-        backgroundColor = "75a0ab",
-        streakColors = "ffffff,e69ecb",
-        introLaunch = false,
-        finalLaunch = false, 
-        borders = true,
-        dark = false
+        backgroundColor = "75A0AB",
+        streakColors = "FFFFFF,E69ECB",
+	dialog = "",
+	introLaunch = false,
+	finalLaunch = false,
+	borders = true,
+	dark = false
     }
 }
 

--- a/SaladimHelper/ModFolder/Loenn/lang/en_gb.lang
+++ b/SaladimHelper/ModFolder/Loenn/lang/en_gb.lang
@@ -14,6 +14,13 @@ entities.SaladimHelper/DelayedFallingBlock.attributes.description.autoFall=The b
 entities.SaladimHelper/RustyZipMover.placements.name.normal=Rusty Zip Mover
 
 entities.SaladimHelper/CustomAscendManager.placements.name.normal=Custom Ascend Manager
+entities.SaladimHelper/CustomAscendManager.attributes.description.backgroundColor=The color to use for the background during the launch.
+entities.SaladimHelper/CustomAscendManager.attributes.description.streakColors=A comma-separated list of colors to use for streaks during the launch.
+entities.SaladimHelper/CustomAscendManager.attributes.description.dialog=The dialog ID to play mid-launch.\nLeave blank for no dialogue.
+entities.SaladimHelper/CustomAscendManager.attributes.description.introLaunch=Whether this launch is at the start of the chapter like in 7A.\nIf so, it will have different movement and cannot have dialogue.
+entities.SaladimHelper/CustomAscendManager.attributes.description.finalLaunch=Whether this launch is at the end of the chapter like in Farewell.\nIf so, it will have different movement and cannot have dialogue.
+entities.SaladimHelper/CustomAscendManager.attributes.description.borders=Whether this launch will have thin borders at the side, colored like the streaks.\nAll vanilla launches have this.
+entities.SaladimHelper/CustomAscendManager.attributes.description.dark=Whether this launch should use the dark colors from the start of Farewell.
 
 entities.SaladimHelper/FlagRefill.placements.name.normal=Flag Custom Refill
 


### PR DESCRIPTION
Adds a field for a dialogue ID. If left empty, no dialogue will play; if there's a valid dialogue ID, Badeline will pop out of Madeline like in Summit and they'll talk to each other. Tested, should have no issues.
(Also added tooltips to the Loenn plugin.)

添加对话 ID 字段。如果为空，则不会播放对话；如果有一个有效的对话 ID，Badeline 就会从 Madeline 身上跳出来，就像《巅峰对决》中那样，他们会互相对话。经过测试，应该没有问题。
(同时还为 Loenn 插件添加了工具提示。用 DeepL 进行了翻译）。